### PR TITLE
Propagate error messages correclty

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: test
 on: [push, pull_request]
 jobs:
   linux:
-    name: test
+    name: Test
     runs-on: ubuntu-latest
     steps:
     - name: Start solana

--- a/build-test-examples.sh
+++ b/build-test-examples.sh
@@ -1,5 +1,5 @@
 for example in $(shx ls -d test/examples/*/); do\
     shx rm -rf ${example}/build; \
     shx mkdir -p ${example}/build; \
-    docker run --rm -t -v $PWD/${example}:/example --entrypoint /bin/bash ghcr.io/hyperledger-labs/solang -c "solang /example/contracts/*.sol -o /example/build --target solana -v"; \
+    docker run --rm -t -v $PWD/${example}:/example --entrypoint /bin/bash ghcr.io/hyperledger-labs/solang -c "solang compile /example/contracts/*.sol -o /example/build --target solana -v"; \
 done

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
         "docs": "shx rm -rf docs && NODE_OPTIONS=--max_old_space_size=4096 typedoc && shx cp .nojekyll docs/",
         "deploy:docs": "gh-pages --dist docs --dotfiles",
         "build:test": "./build-test-examples.sh",
-        "test": "yarn test:unit; yarn test:examples",
+        "test": "yarn test:unit && yarn test:examples",
         "test:unit": "mocha test/unit/**/*.test.ts",
         "test:examples": "mocha test/examples/**/*.test.ts",
         "fmt": "prettier --write '{*,**/*}.{js,ts,jsx,tsx,json}'",

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -34,7 +34,7 @@ export interface ContractCallOptions {
     sender?: PublicKey | undefined;
     value?: number | bigint;
     simulate?: boolean;
-    ed25519sigs?: Ed25519SigCheck[],
+    ed25519sigs?: Ed25519SigCheck[];
     confirmOptions?: ConfirmOptions;
 }
 
@@ -267,12 +267,14 @@ export class Contract {
             keys.push({ pubkey: SYSVAR_INSTRUCTIONS_PUBKEY, isSigner: false, isWritable: false });
 
             ed25519sigs.forEach(({ publicKey, message, signature }, index) => {
-                transaction.add(Ed25519Program.createInstructionWithPublicKey({
-                    instructionIndex: index,
-                    publicKey: publicKey.toBuffer(),
-                    message,
-                    signature,
-                }));
+                transaction.add(
+                    Ed25519Program.createInstructionWithPublicKey({
+                        instructionIndex: index,
+                        publicKey: publicKey.toBuffer(),
+                        message,
+                        signature,
+                    })
+                );
             });
         }
 
@@ -481,12 +483,14 @@ export class Contract {
             keys.push({ pubkey: SYSVAR_INSTRUCTIONS_PUBKEY, isSigner: false, isWritable: false });
 
             ed25519sigs.forEach(({ publicKey, message, signature }, index) => {
-                transaction.add(Ed25519Program.createInstructionWithPublicKey({
-                    instructionIndex: index,
-                    publicKey: publicKey.toBuffer(),
-                    message,
-                    signature,
-                }));
+                transaction.add(
+                    Ed25519Program.createInstructionWithPublicKey({
+                        instructionIndex: index,
+                        publicKey: publicKey.toBuffer(),
+                        message,
+                        signature,
+                    })
+                );
             });
         }
 
@@ -503,11 +507,11 @@ export class Contract {
             simulate || fragment.stateMutability === 'view' || fragment.stateMutability === 'pure'
                 ? await simulateTransactionWithLogs(this.connection, transaction, [payer, ...signers])
                 : await sendAndConfirmTransactionWithLogs(
-                    this.connection,
-                    transaction,
-                    [payer, ...signers],
-                    confirmOptions
-                );
+                      this.connection,
+                      transaction,
+                      [payer, ...signers],
+                      confirmOptions
+                  );
 
         const events = this.parseLogsEvents(logs);
 
@@ -524,8 +528,7 @@ export class Contract {
             }
         }
 
-        if (returnResult === true)
-            return result as any;
+        if (returnResult === true) return result as any;
         return { result, logs, events, computeUnitsUsed };
     }
 }

--- a/src/logs.ts
+++ b/src/logs.ts
@@ -9,7 +9,7 @@ const LOG_LOG_PREFIX = 'Program log: ';
 const LOG_COMPUTE_UNITS_REGEX = /consumed (\d+) of (\d+) compute units/i;
 const LOG_DATA_PREFIX = 'Program data: ';
 const LOG_FAILED_TO_COMPLETE_PREFIX = 'Program failed to complete: ';
-const LOG_FAILED_REGEX = /(Program \w+ )?(failed: )?(.*)$/;
+const LOG_FAILED_REGEX = /(Program \w+ )?failed: (.*)$/;
 
 /** @internal */
 export class LogsParser {
@@ -110,7 +110,7 @@ export async function simulateTransactionWithLogs(
     const logs = result.value.logs ?? [];
     const { log, encoded, computeUnitsUsed } = parseTransactionLogs(logs);
 
-    if (result.value.err) throw parseTransactionError(encoded, computeUnitsUsed, log, logs);
+    if (result.value.err) throw parseTransactionError(encoded, computeUnitsUsed, log, logs, null);
 
     return { logs, encoded, computeUnitsUsed };
 }
@@ -144,7 +144,7 @@ export async function sendAndConfirmTransactionWithLogs(
             if (error.logs && error.logs.length != 0) {
                 const { encoded, computeUnitsUsed } = parseTransactionLogs(error.logs);
 
-                throw parseTransactionError(encoded, computeUnitsUsed, null, error.logs);
+                throw parseTransactionError(encoded, computeUnitsUsed, null, error.logs, error.message);
             }
         }
 
@@ -184,7 +184,8 @@ export function parseTransactionError(
     encoded: Buffer | null,
     computeUnitsUsed: number,
     log: string | null,
-    logs: string[]
+    logs: string[],
+    message: string | null,
 ): TransactionError {
     let error: TransactionError;
 
@@ -192,7 +193,7 @@ export function parseTransactionError(
         error = new TransactionError(log);
     } else if (!encoded) {
         const failedMatch = logs[logs.length - 1].match(LOG_FAILED_REGEX);
-        error = failedMatch ? new TransactionError(failedMatch[3]) : new TransactionError('return data or log not set');
+        error = failedMatch ? new TransactionError(failedMatch[2]) : message ? new TransactionError(message) : new TransactionError('return data or log not set');
     } else if (encoded.readUInt32BE(0) != 0x08c379a0) {
         error = new TransactionError('signature not correct');
     } else {

--- a/src/logs.ts
+++ b/src/logs.ts
@@ -1,6 +1,14 @@
 import { defaultAbiCoder, LogDescription } from '@ethersproject/abi';
 import { hexDataSlice } from '@ethersproject/bytes';
-import { ConfirmOptions, SendTransactionError, Connection, Finality, sendAndConfirmTransaction, Signer, Transaction } from '@solana/web3.js';
+import {
+    ConfirmOptions,
+    SendTransactionError,
+    Connection,
+    Finality,
+    sendAndConfirmTransaction,
+    Signer,
+    Transaction,
+} from '@solana/web3.js';
 import { Contract, EventListener, LogListener } from './contract';
 import { TransactionError } from './errors';
 
@@ -138,8 +146,7 @@ export async function sendAndConfirmTransactionWithLogs(
         const { encoded, computeUnitsUsed } = parseTransactionLogs(logs);
 
         return { logs, encoded, computeUnitsUsed };
-    }
-    catch (error) {
+    } catch (error) {
         if (error instanceof SendTransactionError) {
             if (error.logs && error.logs.length != 0) {
                 const { encoded, computeUnitsUsed } = parseTransactionLogs(error.logs);
@@ -185,7 +192,7 @@ export function parseTransactionError(
     computeUnitsUsed: number,
     log: string | null,
     logs: string[],
-    message: string | null,
+    message: string | null
 ): TransactionError {
     let error: TransactionError;
 
@@ -193,7 +200,11 @@ export function parseTransactionError(
         error = new TransactionError(log);
     } else if (!encoded) {
         const failedMatch = logs[logs.length - 1].match(LOG_FAILED_REGEX);
-        error = failedMatch ? new TransactionError(failedMatch[2]) : message ? new TransactionError(message) : new TransactionError('return data or log not set');
+        error = failedMatch
+            ? new TransactionError(failedMatch[2])
+            : message
+            ? new TransactionError(message)
+            : new TransactionError('return data or log not set');
     } else if (encoded.readUInt32BE(0) != 0x08c379a0) {
         error = new TransactionError('signature not correct');
     } else {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -26,7 +26,6 @@ export async function createProgramDerivedAddress(program: PublicKey): Promise<P
         let address: PublicKey;
         try {
             address = await PublicKey.createProgramAddress([seed], program);
-
         } catch (error) {
             // If a valid PDA can't be found using the seed, generate another and try again
             continue;

--- a/test/examples/sig-check/sig-check.test.ts
+++ b/test/examples/sig-check/sig-check.test.ts
@@ -17,12 +17,9 @@ describe('Signature Check', () => {
         const message = Buffer.from('Foobar');
         const signature = nacl.sign.detached(message, storage.secretKey);
 
-        const { result } = await contract.functions.verify(
-            publicKeyToHex(storage.publicKey), message, signature,
-            {
-                ed25519sigs: [{ publicKey: storage.publicKey, message, signature }],
-            }
-        );
+        const { result } = await contract.functions.verify(publicKeyToHex(storage.publicKey), message, signature, {
+            ed25519sigs: [{ publicKey: storage.publicKey, message, signature }],
+        });
 
         expect(result).toEqual(true);
     });

--- a/test/unit/logs.test.ts
+++ b/test/unit/logs.test.ts
@@ -38,7 +38,7 @@ describe('logs', () => {
         expect(computeUnitsUsed).toBeGreaterThan(1000);
         expect(computeUnitsUsed).toBeLessThan(1100);
 
-        const err = parseTransactionError(encoded, computeUnitsUsed, null, logs);
+        const err = parseTransactionError(encoded, computeUnitsUsed, null, logs, null);
         expect(err.message).toBe('Do the revert thing');
         expect(err.computeUnitsUsed).toBe(1023);
         expect(err.logs.length).toBeGreaterThan(1);
@@ -80,5 +80,24 @@ describe('logs', () => {
         expect(args[0].toString()).toEqual('500332');
         expect(args[1]).toEqual('0x41424344');
         expect(args[2]).toEqual('0xcafe0123');
+    });
+
+    it('Throw error message', async function () {
+        const logs = [
+            'Program 6aZJGCxKcMXpj4N47mpAf3TCUvzvwe9F2McQsbU3FZaK invoke [1]',
+            'Program 11111111111111111111111111111111 invoke [2]',
+            'Program 11111111111111111111111111111111 success',
+            'Program 6aZJGCxKcMXpj4N47mpAf3TCUvzvwe9F2McQsbU3FZaK consumed 2358 of 1400000 compute units',
+            'Program 6aZJGCxKcMXpj4N47mpAf3TCUvzvwe9F2McQsbU3FZaK success',
+        ];
+        const { encoded, computeUnitsUsed } = parseTransactionLogs(logs);
+        expect(computeUnitsUsed).toBeGreaterThan(1000);
+        expect(computeUnitsUsed).toBeLessThan(2500);
+
+        const err = parseTransactionError(encoded, computeUnitsUsed, null, logs, 'This is an error message');
+        console.log(err);
+        expect(err.message).toBe('This is an error message');
+        expect(err.computeUnitsUsed).toBe(2358);
+        expect(err.logs.length).toBeGreaterThan(1);
     });
 });


### PR DESCRIPTION
This PR changes two things in this library:


1. The utilized regex for retrieving error is wrong. When the long contains `Program 11111111111 success`, `success` was identified as an error.
2. In a few cases, the error is at `error.message`. This was not detected and the library was raising `return data or log not set` without any clue to developers about what was exactly happening.
3. `build-test-example.sh` has been updated with Solang's `compile` subcommand.
4. Github CI now runs unit tests too.
5. I ran `yarn lint:fix` to format the files.