### PR TITLE
Add hexToPublicKey function

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -46,6 +46,22 @@ export function publicKeyToHex(publicKey: PublicKey): string {
     return '0x' + publicKey.toBuffer().toString('hex');
 }
 
+/**
+ * Decode a public key from a hexadeciaml string
+ * 
+ * @param hex The hexadecimal string
+ * 
+ * @returns The correspoding Publick Key
+ */
+export function HexToPublicKey(hex: string) : PublicKey {
+    let new_string = hex.substring(2);
+    let bytes = [];
+    for(let c = 0; c < new_string.length; c+= 2) {
+        bytes.push(parseInt(new_string.substring(c, c+2), 16));
+    }
+    return new PublicKey(bytes);
+}
+
 /** @internal */
 export type Seed = string | PublicKey | Uint8Array | Buffer;
 

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -1,7 +1,8 @@
-import { PublicKey } from '@solana/web3.js';
+import { Keypair, PublicKey } from '@solana/web3.js';
+import { assert } from 'console';
 import expect from 'expect';
 
-import { encodeSeeds, publicKeyToHex } from '../../src/utils';
+import { encodeSeeds, HexToPublicKey, publicKeyToHex } from '../../src/utils';
 
 describe('utils', () => {
     it('pubKeyToHex works', async function () {
@@ -39,5 +40,12 @@ describe('utils', () => {
         expect(encodeSeeds([new PublicKey('G5j33ePDCSZddCogbXqffse9aMrj5684EXJHWfXB7W8K')]).toString('hex')).toEqual(
             '0120e01528146c7b580018be6bcfaf1d3ca0deb2e145abf912f8a4a82eec6e399f0c'
         );
+    });
+
+    it('Decode Hex String', async function () {
+        const pubkey = Keypair.generate();
+        const string_hex = publicKeyToHex(pubkey.publicKey);
+        const retrieved_key = HexToPublicKey(string_hex);
+        expect(pubkey.publicKey).toEqual(retrieved_key);
     });
 });


### PR DESCRIPTION
When we return an address from Solidity, we must be able to transform it to PublicKey again in Typescript. The function `hexToPublicKey` should make that possible.