### PR TITLE
Implement borsh encoding ⚓

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ touch erc20.js
 
 ```js
 const { Connection, LAMPORTS_PER_SOL, Keypair } = require('@solana/web3.js');
-const { Contract, publicKeyToHex } = require('@solana/solidity');
+const { Contract } = require('@solana/solidity');
 const { readFileSync } = require('fs');
 
 const ERC20_ABI = JSON.parse(readFileSync('./build/ERC20.abi', 'utf8'));
@@ -128,7 +128,7 @@ const BUNDLE_SO = readFileSync('./build/bundle.so');
 
     console.log('Sending tokens will emit a "Transfer" event ...');
     const recipient = Keypair.generate();
-    await contract.transfer(publicKeyToHex(recipient.publicKey), '1000000000000000000');
+    await contract.transfer(recipient.publicKey.toBytes(), 1000000000000000000);
 
     process.exit(0);
 })();

--- a/package.json
+++ b/package.json
@@ -42,14 +42,17 @@
         "validator": "docker run --rm -it -p 8899:8899 -p 8900:8900 solanalabs/solana:edge > /dev/null"
     },
     "dependencies": {
+        "@dao-xyz/borsh": "^3.3.0",
         "@ethersproject/abi": "^5.5.0",
         "@ethersproject/bytes": "^5.5.0",
         "@ethersproject/keccak256": "^5.5.0",
         "@ethersproject/properties": "^5.5.0",
-        "@solana/web3.js": "^1.30.2"
+        "@solana/web3.js": "^1.30.2",
+        "bn.js": "^5.2.1"
     },
     "devDependencies": {
         "@ethersproject/contracts": "^5.5.0",
+        "@types/bs58": "^4.0.1",
         "@types/eslint": "^7.28.2",
         "@types/eslint-plugin-prettier": "^3.1.0",
         "@types/mocha": "^9.0.0",
@@ -68,7 +71,6 @@
         "ts-node": "^10.4.0",
         "tslib": "^2.3.1",
         "typedoc": "^0.22.7",
-        "typescript": "^4.4.4",
-        "@types/bs58": "^4.0.1"
+        "typescript": "^4.4.4"
     }
 }

--- a/src/borsh.ts
+++ b/src/borsh.ts
@@ -1,0 +1,447 @@
+import { ParamType, Result } from '@ethersproject/abi';
+import { BinaryReader, BinaryWriter } from '@dao-xyz/borsh';
+import BN from 'bn.js';
+
+/**
+ * Encode the arguments of a function using Borsh encoding
+ * @param params an array containing the description of each parameter
+ * @param values an array containing the arguments
+ */
+export function borshEncode(params: ReadonlyArray<ParamType>, values: ReadonlyArray<any>): Uint8Array {
+    const writer = new SolidityWriter();
+    const total_params = params.length;
+    for (let i = 0; i < total_params; i++) {
+        encodeParam(params[i], values[i], writer);
+    }
+    return writer.toArray();
+}
+
+/** @internal
+ * Encode a single function parameter
+ * @param param a function parameter
+ * @param value the argument passed for that parameter
+ * @param writer the entity that writes to a buffer
+ */
+function encodeParam(param: ParamType, value: any, writer: SolidityWriter) {
+    switch (param.baseType) {
+        case 'int8': {
+            writer.writeI8(value);
+            break;
+        }
+        case 'uint8': {
+            writer.writeU8(value);
+            break;
+        }
+        case 'int16': {
+            writer.writeI16(value);
+            break;
+        }
+        case 'uint16': {
+            writer.writeU16(value);
+            break;
+        }
+        case 'int32': {
+            writer.writeI32(value);
+            break;
+        }
+        case 'uint32': {
+            writer.writeU32(value);
+            break;
+        }
+        case 'int64': {
+            writer.writeI64(BigInt(value));
+            break;
+        }
+        case 'uint64': {
+            writer.writeU64(value);
+            break;
+        }
+        case 'int128': {
+            writer.writeI128(value);
+            break;
+        }
+        case 'uint128': {
+            writer.writeU128(value);
+            break;
+        }
+        case 'int256': {
+            writer.writeI256(value);
+            break;
+        }
+        case 'uint256': {
+            writer.writeU256(value);
+            break;
+        }
+
+        case 'address': {
+            writer.writeFixedArray(value);
+            break;
+        }
+
+        case 'bytes1':
+        case 'bytes2':
+        case 'bytes3':
+        case 'bytes4':
+        case 'bytes5':
+        case 'bytes6':
+        case 'bytes7':
+        case 'bytes8':
+        case 'bytes9':
+        case 'bytes10':
+        case 'bytes11':
+        case 'bytes12':
+        case 'bytes13':
+        case 'bytes14':
+        case 'bytes15':
+        case 'bytes16':
+        case 'bytes17':
+        case 'bytes18':
+        case 'bytes19':
+        case 'bytes20':
+        case 'bytes21':
+        case 'bytes22':
+        case 'bytes23':
+        case 'bytes24':
+        case 'bytes25':
+        case 'bytes26':
+        case 'bytes27':
+        case 'bytes28':
+        case 'bytes29':
+        case 'bytes30':
+        case 'bytes31':
+        case 'bytes32': {
+            writer.writeFixedArray(value);
+            break;
+        }
+
+        case 'bool': {
+            writer.writeBool(value);
+            break;
+        }
+
+        case 'bytes': {
+            writer.writeU32(value.length);
+            writer.writeFixedArray(value);
+            break;
+        }
+
+        case 'string': {
+            writer.writeString(value);
+            break;
+        }
+
+        case 'tuple': {
+            const items_len = param.components.length;
+            for (let i = 0; i < items_len; i++) {
+                encodeParam(param.components[i], value[i], writer);
+            }
+            break;
+        }
+
+        case 'array': {
+            let len = 0;
+            if (param.arrayLength == -1) {
+                writer.writeU32(value.length);
+                len = value.length;
+            } else {
+                len = param.arrayLength;
+            }
+            for (let i = 0; i < len; i++) {
+                encodeParam(param.arrayChildren, value[i], writer);
+            }
+            break;
+        }
+    }
+}
+
+/**
+ * Decodes the returns of a function
+ * @param params an array containing the description of each return
+ * @param encoded a buffer that holds the encoded returns
+ */
+export function borshDecode(params: ArrayLike<ParamType>, encoded: Buffer): Result {
+    const decoded_items: Array<any> = new Array<any>();
+    const reader = new SolidityBinaryReader(encoded);
+    for (let i = 0; i < params.length; i++) {
+        const item = decodeParam(params[i], reader);
+        decoded_items.push(item);
+    }
+
+    return decoded_items;
+}
+
+/**
+ * @internal
+ * Read a returned item from a buffer
+ * @param param the parameter we want to read
+ * @param reader the entity that reads from the buffer
+ */
+function decodeParam(param: ParamType, reader: SolidityBinaryReader): any {
+    switch (param.baseType) {
+        case 'int8': {
+            return reader.readI8();
+        }
+        case 'uint8': {
+            return reader.readU8();
+        }
+        case 'int16': {
+            return reader.readI16();
+        }
+        case 'uint16': {
+            return reader.readU16();
+        }
+        case 'int32': {
+            return reader.readI32();
+        }
+        case 'uint32': {
+            return reader.readU32();
+        }
+        case 'int64': {
+            return reader.readI64();
+        }
+        case 'uint64': {
+            return reader.readU64();
+        }
+        case 'int128': {
+            return reader.readI128();
+        }
+        case 'uint128': {
+            return reader.readU128();
+        }
+        case 'int256': {
+            return reader.readI256();
+        }
+        case 'uint256': {
+            return reader.readU256();
+        }
+        case 'bytes1': {
+            return reader.readFixedArray(1);
+        }
+        case 'bytes2': {
+            return reader.readFixedArray(2);
+        }
+        case 'bytes3': {
+            return reader.readFixedArray(3);
+        }
+        case 'bytes4': {
+            return reader.readFixedArray(4);
+        }
+        case 'bytes5': {
+            return reader.readFixedArray(5);
+        }
+        case 'bytes6': {
+            return reader.readFixedArray(6);
+        }
+        case 'bytes7': {
+            return reader.readFixedArray(7);
+        }
+        case 'bytes8': {
+            return reader.readFixedArray(8);
+        }
+        case 'bytes9': {
+            return reader.readFixedArray(9);
+        }
+        case 'bytes10': {
+            return reader.readFixedArray(10);
+        }
+        case 'bytes11': {
+            return reader.readFixedArray(11);
+        }
+        case 'bytes12': {
+            return reader.readFixedArray(12);
+        }
+        case 'bytes13': {
+            return reader.readFixedArray(13);
+        }
+        case 'bytes14': {
+            return reader.readFixedArray(14);
+        }
+        case 'bytes15': {
+            return reader.readFixedArray(15);
+        }
+        case 'bytes16': {
+            return reader.readFixedArray(16);
+        }
+        case 'bytes17': {
+            return reader.readFixedArray(17);
+        }
+        case 'bytes18': {
+            return reader.readFixedArray(18);
+        }
+        case 'bytes19': {
+            return reader.readFixedArray(19);
+        }
+        case 'bytes20': {
+            return reader.readFixedArray(20);
+        }
+        case 'bytes21': {
+            return reader.readFixedArray(21);
+        }
+        case 'bytes22': {
+            return reader.readFixedArray(22);
+        }
+        case 'bytes23': {
+            return reader.readFixedArray(23);
+        }
+        case 'bytes24': {
+            return reader.readFixedArray(24);
+        }
+        case 'bytes25': {
+            return reader.readFixedArray(25);
+        }
+        case 'bytes26': {
+            return reader.readFixedArray(26);
+        }
+        case 'bytes27': {
+            return reader.readFixedArray(27);
+        }
+        case 'bytes28': {
+            return reader.readFixedArray(28);
+        }
+        case 'bytes29': {
+            return reader.readFixedArray(29);
+        }
+        case 'bytes30': {
+            return reader.readFixedArray(30);
+        }
+        case 'bytes31': {
+            return reader.readFixedArray(31);
+        }
+        case 'address':
+        case 'bytes32': {
+            return reader.readFixedArray(32);
+        }
+
+        case 'bool': {
+            return reader.readBool();
+        }
+
+        case 'bytes': {
+            const len = reader.readU32();
+            return reader.readFixedArray(len);
+        }
+
+        case 'string': {
+            return reader.readString();
+        }
+
+        case 'tuple': {
+            const tuple_len = param.components.length;
+            const response: Array<any> = new Array<any>();
+            for (let i = 0; i < tuple_len; i++) {
+                response.push(decodeParam(param.components[i], reader));
+            }
+            return response;
+        }
+
+        case 'array': {
+            let len = 0;
+            if (param.arrayLength == -1) {
+                len = reader.readU32();
+            } else {
+                len = param.arrayLength;
+            }
+            const response: Array<any> = new Array<any>();
+            for (let i = 0; i < len; i++) {
+                response.push(decodeParam(param.arrayChildren, reader));
+            }
+            return response;
+        }
+    }
+}
+
+/**
+ * This class extends BinaryReader to implement function for reading signed numbers from a borsh encoded buffer.
+ */
+class SolidityBinaryReader extends BinaryReader {
+    public constructor(buf: Buffer) {
+        super(buf);
+    }
+
+    readI8(): number {
+        const value = this.buf.getInt8(this.offset);
+        this.offset += 1;
+        return value;
+    }
+
+    readI16(): number {
+        const value = this.buf.getInt16(this.offset, true);
+        this.offset += 2;
+        return value;
+    }
+
+    readI32(): number {
+        const value = this.buf.getInt32(this.offset, true);
+        this.offset += 4;
+        return value;
+    }
+
+    readI64(): bigint {
+        const value = this.buf.getBigInt64(this.offset, true);
+        this.offset += 8;
+        return value;
+    }
+
+    readI128(): bigint {
+        const read = this.readFixedArray(16);
+        let bigNumber = new BN(read, 'le');
+        bigNumber = bigNumber.fromTwos(128);
+        const str = bigNumber.toString();
+        return BigInt(str);
+    }
+
+    readI256(): bigint {
+        const read = this.readFixedArray(32);
+        let bigNumber = new BN(read, 'le');
+        bigNumber = bigNumber.fromTwos(256);
+        const str = bigNumber.toString();
+        return BigInt(str);
+    }
+}
+
+/**
+ * This class extends BinaryWrite to implement function that write signed numbers when borsh encoding
+ */
+class SolidityWriter extends BinaryWriter {
+    constructor() {
+        super();
+    }
+
+    writeI8(value: number) {
+        this.maybeResize();
+        this.buf.setInt8(this.length, value);
+        this.length += 1;
+    }
+
+    writeI16(value: number) {
+        this.maybeResize();
+        this.buf.setInt16(this.length, value, true);
+        this.length += 2;
+    }
+
+    writeI32(value: number) {
+        this.maybeResize();
+        this.buf.setInt32(this.length, value, true);
+        this.length += 4;
+    }
+
+    writeI64(value: bigint) {
+        this.maybeResize();
+        this.buf.setBigInt64(this.length, value, true);
+        this.length += 8;
+    }
+
+    writeI128(value: bigint) {
+        let bigNumber = new BN(value.toString());
+        bigNumber = bigNumber.toTwos(128);
+        const arrayLike = bigNumber.toBuffer('le', 16);
+        this.writeFixedArray(arrayLike);
+    }
+
+    writeI256(value: bigint) {
+        let bigNumber = new BN(value.toString());
+        bigNumber = bigNumber.toTwos(256);
+        const arrayLike = bigNumber.toBuffer('le', 32);
+        this.writeFixedArray(arrayLike);
+    }
+}

--- a/test/examples/errors/errors.test.ts
+++ b/test/examples/errors/errors.test.ts
@@ -19,8 +19,8 @@ describe('Errors', () => {
         } catch (error) {
             if (!(error instanceof TransactionError)) throw error;
             expect(error.message).toBe('Do the revert thing');
-            expect(error.computeUnitsUsed).toBeGreaterThan(1000);
-            expect(error.computeUnitsUsed).toBeLessThan(1100);
+            expect(error.computeUnitsUsed).toBeGreaterThan(1400);
+            expect(error.computeUnitsUsed).toBeLessThan(1600);
             expect(error.logs.length).toBeGreaterThan(1);
             return;
         }
@@ -71,8 +71,8 @@ describe('Errors', () => {
         } catch (error) {
             if (!(error instanceof TransactionError)) throw error;
             expect(error.message).toBe('Do the revert thing');
-            expect(error.computeUnitsUsed).toBeGreaterThan(1000);
-            expect(error.computeUnitsUsed).toBeLessThan(1200);
+            expect(error.computeUnitsUsed).toBeGreaterThan(1200);
+            expect(error.computeUnitsUsed).toBeLessThan(1600);
             expect(error.logs.length).toBeGreaterThan(1);
             return;
         }

--- a/test/examples/named-returns/named-returns.test.ts
+++ b/test/examples/named-returns/named-returns.test.ts
@@ -12,7 +12,7 @@ describe('Named Returns', () => {
 
     it('work', async function () {
         const {
-            result: { a, b },
+            result: [a, b],
         } = await contract.functions.noop(1, 2);
         expect(a.toString()).toEqual('1');
         expect(b.toString()).toEqual('2');

--- a/test/examples/sig-check/sig-check.test.ts
+++ b/test/examples/sig-check/sig-check.test.ts
@@ -1,7 +1,7 @@
 import { Keypair } from '@solana/web3.js';
 import expect from 'expect';
 import nacl from 'tweetnacl';
-import { Contract, publicKeyToHex } from '../../../src';
+import { Contract } from '../../../src';
 import { loadContract } from '../utils';
 
 describe('Signature Check', () => {
@@ -17,7 +17,7 @@ describe('Signature Check', () => {
         const message = Buffer.from('Foobar');
         const signature = nacl.sign.detached(message, storage.secretKey);
 
-        const { result } = await contract.functions.verify(publicKeyToHex(storage.publicKey), message, signature, {
+        const { result } = await contract.functions.verify(storage.publicKey.toBytes(), message, signature, {
             ed25519sigs: [{ publicKey: storage.publicKey, message, signature }],
         });
 

--- a/test/examples/simulate/simulate.test.ts
+++ b/test/examples/simulate/simulate.test.ts
@@ -14,8 +14,8 @@ describe('Simulate', () => {
         const { result, logs, computeUnitsUsed } = await contract.functions.add(1, 2, { simulate: true }); // @FIXME: how do we ensure this is testing simulation?
         expect(result.toString()).toBe('3');
         expect(logs.length).toBeGreaterThan(1);
-        expect(computeUnitsUsed).toBeGreaterThan(1500);
-        expect(computeUnitsUsed).toBeLessThan(2000);
+        expect(computeUnitsUsed).toBeGreaterThan(800);
+        expect(computeUnitsUsed).toBeLessThan(1000);
 
         try {
             await contract.functions.div(1, 0, { simulate: true }); // @FIXME: how do we ensure this is testing simulation?

--- a/test/examples/tx-params/tx-params.test.ts
+++ b/test/examples/tx-params/tx-params.test.ts
@@ -14,7 +14,7 @@ describe('TxParams', () => {
         const { result, logs, computeUnitsUsed } = await contract.functions.sum([1, 2, 3]);
         expect(result.toString()).toBe('6');
         expect(logs.length).toBeGreaterThan(1);
-        expect(computeUnitsUsed).toBeGreaterThan(2600);
+        expect(computeUnitsUsed).toBeGreaterThan(2400);
         expect(computeUnitsUsed).toBeLessThan(3200);
     });
 
@@ -24,7 +24,7 @@ describe('TxParams', () => {
         });
         expect(result.toString()).toBe('6');
         expect(logs.length).toBeGreaterThan(1);
-        expect(computeUnitsUsed).toBeGreaterThan(2600);
+        expect(computeUnitsUsed).toBeGreaterThan(2400);
         expect(computeUnitsUsed).toBeLessThan(3200);
     });
 });

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,4 +1,7 @@
 {
+    "compilerOptions": {
+        "experimentalDecorators": true
+    },
     "extends": "../tsconfig.json",
     "include": ["."]
 }

--- a/test/unit/borsh.test.ts
+++ b/test/unit/borsh.test.ts
@@ -1,0 +1,66 @@
+import { ParamType } from '@ethersproject/abi';
+import { borshDecode, borshEncode } from '../../src/borsh';
+import expect from 'expect';
+
+describe('borsh encode and decode', () => {
+    it('signed integers', async function () {
+        const params: Array<ParamType> = [
+            ParamType.fromString('int8'),
+            ParamType.fromString('int16'),
+            ParamType.fromString('int32'),
+            ParamType.fromString('int64'),
+            ParamType.fromString('int128'),
+            ParamType.from('int256'),
+        ];
+
+        const args = [-90, -3322, -2134123, BigInt(-72344), BigInt(-9123123), BigInt(-6612344554)];
+
+        const encoded = borshEncode(params, args);
+        const decoded = borshDecode(params, Buffer.from(encoded));
+
+        expect(decoded[0]).toStrictEqual(args[0]);
+        expect(decoded[1]).toStrictEqual(args[1]);
+        expect(decoded[2]).toStrictEqual(args[2]);
+        expect(decoded[3]).toStrictEqual(args[3]);
+        expect(decoded[4]).toStrictEqual(args[4]);
+        expect(decoded[5]).toStrictEqual(args[5]);
+    });
+
+    it('unsigned integers', async function () {
+        const params: Array<ParamType> = [
+            ParamType.fromString('uint8'),
+            ParamType.fromString('uint16'),
+            ParamType.fromString('uint32'),
+            ParamType.fromString('uint64'),
+            ParamType.fromString('uint128'),
+            ParamType.from('uint256'),
+        ];
+
+        const args = [90, 3322, 2134123, BigInt(72344), BigInt(9123123), BigInt(6612344554)];
+
+        const encoded = borshEncode(params, args);
+        const decoded = borshDecode(params, Buffer.from(encoded));
+
+        expect(decoded[0]).toStrictEqual(args[0]);
+        expect(decoded[1]).toStrictEqual(args[1]);
+        expect(decoded[2]).toStrictEqual(args[2]);
+        expect(decoded[3]).toStrictEqual(args[3]);
+        expect(decoded[4]).toStrictEqual(args[4]);
+        expect(decoded[5]).toStrictEqual(args[5]);
+    });
+
+    it('bytes', async function () {
+        for (let i = 2; i < 33; i++) {
+            const params = [
+                ParamType.fromString('bytes' + (i - 1).toString()),
+                ParamType.fromString('bytes' + i.toString()),
+            ];
+            const args = [new Uint8Array(i - 1), new Uint8Array(i)];
+
+            const encoded = borshEncode(params, args);
+            const decoded = borshDecode(params, Buffer.from(encoded));
+            expect(decoded[0]).toStrictEqual(args[0]);
+            expect(decoded[1]).toStrictEqual(args[1]);
+        }
+    });
+});

--- a/test/unit/borsh_decoding.test.ts
+++ b/test/unit/borsh_decoding.test.ts
@@ -1,0 +1,145 @@
+import { field, fixedArray, serialize, vec } from '@dao-xyz/borsh';
+import { ParamType } from '@ethersproject/abi';
+import { borshDecode } from '../../src/borsh';
+import expect from 'expect';
+
+describe('borsh decoding', () => {
+    class PrimitiveTypes {
+        @field({ type: 'u32' })
+        param_zero: number;
+
+        @field({ type: 'u256' })
+        param_one: bigint;
+
+        @field({ type: fixedArray('u8', 32) })
+        param_two: Uint8Array;
+
+        @field({ type: fixedArray('u8', 5) })
+        param_three: Uint8Array;
+
+        @field({ type: 'bool' })
+        param_four: boolean;
+
+        constructor(data?: {
+            param_zero: number;
+            param_one: bigint;
+            param_two: Uint8Array;
+            param_three: Uint8Array;
+            param_four: boolean;
+        }) {
+            if (data) {
+                this.param_zero = data.param_zero;
+                this.param_one = data.param_one;
+                this.param_two = data.param_two;
+                this.param_three = data.param_three;
+                this.param_four = data.param_four;
+            } else {
+                this.param_zero = 0;
+                this.param_one = BigInt(0);
+                this.param_two = new Uint8Array();
+                this.param_three = new Uint8Array();
+                this.param_four = false;
+            }
+        }
+    }
+    it('primitive types', async function () {
+        const struct_to_encode = new PrimitiveTypes({
+            param_zero: 896514,
+            param_one: BigInt(89663333221478),
+            param_two: new Uint8Array([
+                32, 31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6,
+                5, 4, 3, 2, 1,
+            ]),
+            param_three: new Uint8Array([255, 254, 253, 252, 251]),
+            param_four: false,
+        });
+        const encoded = serialize(struct_to_encode);
+        const params: Array<ParamType> = [
+            ParamType.fromString('uint32'),
+            ParamType.fromString('uint256'),
+            ParamType.fromString('address'),
+            ParamType.fromString('bytes5'),
+            ParamType.fromString('bool'),
+        ];
+
+        const decoded = borshDecode(params, Buffer.from(encoded));
+
+        expect(decoded[0]).toStrictEqual(struct_to_encode.param_zero);
+        expect(decoded[1]).toStrictEqual(struct_to_encode.param_one);
+        expect(decoded[2]).toStrictEqual(struct_to_encode.param_two);
+        expect(decoded[3]).toStrictEqual(struct_to_encode.param_three);
+        expect(decoded[4]).toStrictEqual(struct_to_encode.param_four);
+    });
+
+    class ComplexTypes {
+        @field({ type: vec('u8') })
+        param_zero: Uint8Array;
+
+        @field({ type: 'string' })
+        param_one: string;
+
+        @field({ type: 'u16' })
+        param_two: number;
+
+        @field({ type: 'u8' })
+        param_three: number;
+
+        @field({ type: fixedArray('u64', 4) })
+        param_four: bigint[];
+
+        @field({ type: vec('u32') })
+        param_five: number[];
+
+        constructor(data?: {
+            zero: Uint8Array;
+            one: string;
+            two: number;
+            three: number;
+            four: bigint[];
+            five: number[];
+        }) {
+            if (data) {
+                this.param_zero = data.zero;
+                this.param_one = data.one;
+                this.param_two = data.two;
+                this.param_three = data.three;
+                this.param_four = data.four;
+                this.param_five = data.five;
+            } else {
+                this.param_zero = new Uint8Array();
+                this.param_one = '';
+                this.param_two = 0;
+                this.param_three = 0;
+                this.param_four = [];
+                this.param_five = [];
+            }
+        }
+    }
+
+    it('complex types', async function () {
+        const struct_to_encode = new ComplexTypes({
+            zero: new Uint8Array([24, 45, 44, 33, 87, 65]),
+            one: 'tea',
+            two: -98,
+            three: -9,
+            four: [BigInt(23), BigInt(1234134), BigInt(1874085), BigInt(4324)],
+            five: [900, 9230, 42],
+        });
+
+        const encoded = serialize(struct_to_encode);
+        const params: Array<ParamType> = [
+            ParamType.fromString('bytes'),
+            ParamType.from('string'),
+            ParamType.from('tuple(int16, int8)'),
+            ParamType.from('uint64[4]'),
+            ParamType.from('uint32[]'),
+        ];
+        const res = borshDecode(params, Buffer.from(encoded));
+
+        expect(res[0]).toStrictEqual(struct_to_encode.param_zero);
+        expect(res[1]).toStrictEqual(struct_to_encode.param_one);
+        expect(res[2]).toStrictEqual([struct_to_encode.param_two, struct_to_encode.param_three]);
+        expect(res[3]).toStrictEqual(struct_to_encode.param_four);
+        expect(res[4]).toStrictEqual(struct_to_encode.param_five);
+    });
+});

--- a/test/unit/borsh_encoding.test.ts
+++ b/test/unit/borsh_encoding.test.ts
@@ -1,0 +1,154 @@
+import { ParamType } from '@ethersproject/abi';
+import { field, fixedArray, serialize, vec } from '@dao-xyz/borsh';
+import { borshEncode } from '../../src/borsh';
+import expect from 'expect';
+
+describe('borsh encoding', () => {
+    class PrimitiveTypes {
+        @field({ type: 'u16' })
+        param_zero: number;
+
+        @field({ type: 'u128' })
+        param_one: bigint;
+
+        @field({ type: fixedArray('u8', 32) })
+        param_two: Uint8Array;
+
+        @field({ type: fixedArray('u8', 4) })
+        param_three: Uint8Array;
+
+        @field({ type: 'bool' })
+        param_four: boolean;
+
+        constructor(data?: {
+            param_zero: number;
+            param_one: bigint;
+            param_two: Uint8Array;
+            param_three: Uint8Array;
+            param_four: boolean;
+        }) {
+            if (data) {
+                this.param_zero = data.param_zero;
+                this.param_one = data.param_one;
+                this.param_two = data.param_two;
+                this.param_three = data.param_three;
+                this.param_four = data.param_four;
+            } else {
+                this.param_zero = 0;
+                this.param_one = BigInt(0);
+                this.param_two = new Uint8Array();
+                this.param_three = new Uint8Array();
+                this.param_four = false;
+            }
+        }
+    }
+
+    it('primitive types', async function () {
+        const params: Array<ParamType> = [
+            ParamType.fromString('int16'),
+            ParamType.fromString('uint128'),
+            ParamType.fromString('address'),
+            ParamType.fromString('bytes4'),
+            ParamType.fromString('bool'),
+        ];
+
+        const args: Array<any> = [
+            -986523,
+            BigInt(1924736120347601347),
+            new Uint8Array([
+                0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27,
+                28, 29, 30, 31,
+            ]),
+            new Uint8Array([255, 250, 128, 65]),
+            true,
+        ];
+
+        const encoded_from_typescript = borshEncode(params, args);
+        const struct_to_encode = new PrimitiveTypes({
+            param_zero: args[0],
+            param_one: args[1],
+            param_two: args[2],
+            param_three: args[3],
+            param_four: args[4],
+        });
+        const original_encoded = serialize(struct_to_encode);
+        expect(encoded_from_typescript).toStrictEqual(original_encoded);
+    });
+
+    class ComplexTypes {
+        @field({ type: vec('u8') })
+        param_zero: Uint8Array;
+
+        @field({ type: 'string' })
+        param_one: string;
+
+        @field({ type: 'u16' })
+        param_two: number;
+
+        @field({ type: 'u8' })
+        param_three: number;
+
+        @field({ type: fixedArray('u32', 4) })
+        param_four: number[];
+
+        @field({ type: vec('u32') })
+        param_five: number[];
+
+        constructor(data?: {
+            zero: Uint8Array;
+            one: string;
+            two: number;
+            three: number;
+            four: number[];
+            five: number[];
+        }) {
+            if (data) {
+                this.param_zero = data.zero;
+                this.param_one = data.one;
+                this.param_two = data.two;
+                this.param_three = data.three;
+                this.param_four = data.four;
+                this.param_five = data.five;
+            } else {
+                this.param_zero = new Uint8Array();
+                this.param_one = '';
+                this.param_two = 0;
+                this.param_three = 0;
+                this.param_four = [];
+                this.param_five = [];
+            }
+        }
+    }
+
+    it('complex types', async function () {
+        const params: Array<ParamType> = [
+            ParamType.fromString('bytes'),
+            ParamType.fromString('string'),
+            ParamType.fromString('tuple(uint16, int8)'),
+            ParamType.fromString('int32[4]'),
+            ParamType.fromString('int32[]'),
+        ];
+
+        const args: Array<any> = [
+            new Uint8Array([4, 5, 255, 238, 129]),
+            'cappuccino',
+            [856, -112],
+            [5895, -89, 778, -7445],
+            [85, -556],
+        ];
+
+        const encoded_from_typescript = borshEncode(params, args);
+        const to_be_encoded = new ComplexTypes({
+            zero: args[0],
+            one: args[1],
+            two: args[2][0],
+            three: args[2][1],
+            four: args[3],
+            five: args[4],
+        });
+
+        const borsh_encoded = serialize(to_be_encoded);
+
+        expect(encoded_from_typescript).toStrictEqual(borsh_encoded);
+    });
+});

--- a/test/unit/logs.test.ts
+++ b/test/unit/logs.test.ts
@@ -1,6 +1,7 @@
-import { Interface } from '@ethersproject/abi';
+import { Interface, ParamType } from '@ethersproject/abi';
 import expect from 'expect';
 import { parseLogTopic, parseTransactionError, parseTransactionLogs } from '../../src/logs';
+import { borshEncode } from '../../lib/borsh';
 
 describe('logs', () => {
     it('parses "Program return:" logs', async function () {
@@ -34,11 +35,16 @@ describe('logs', () => {
             'Program return: 9cgeQC4fKNtL4vAk59UBjJwyAgXocDVwZCcnNq5gHrqk CMN5oAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABNEbyB0aGUgcmV2ZXJ0IHRoaW5nAAAAAAAAAAAAAAAAAA==',
             'Program 9cgeQC4fKNtL4vAk59UBjJwyAgXocDVwZCcnNq5gHrqk failed: custom program error: 0x0',
         ];
-        const { encoded, computeUnitsUsed } = parseTransactionLogs(logs);
+        const { computeUnitsUsed } = parseTransactionLogs(logs);
         expect(computeUnitsUsed).toBeGreaterThan(1000);
         expect(computeUnitsUsed).toBeLessThan(1100);
 
-        const err = parseTransactionError(encoded, computeUnitsUsed, null, logs, null);
+        const params = [ParamType.from('uint32'), ParamType.from('string')];
+
+        const args: Array<any> = [0x08c379a0, 'Do the revert thing'];
+
+        const borshEncoded = borshEncode(params, args);
+        const err = parseTransactionError(Buffer.from(borshEncoded), computeUnitsUsed, null, logs, null);
         expect(err.message).toBe('Do the revert thing');
         expect(err.computeUnitsUsed).toBe(1023);
         expect(err.logs.length).toBeGreaterThan(1);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,8 @@
         "esModuleInterop": true,
         "resolveJsonModule": true,
         "isolatedModules": true,
-        "typeRoots": ["node_modules/@types", "types"]
+        "typeRoots": ["node_modules/@types", "types"],
+        "experimentalDecorators": true
     },
     "include": ["src"],
     "exclude": ["node_modules"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -49,6 +49,13 @@
   dependencies:
     "@cspotcode/source-map-consumer" "0.8.0"
 
+"@dao-xyz/borsh@^3.3.0":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/@dao-xyz/borsh/-/borsh-3.3.0.tgz#1fea8c7b405765eeb073b83ba67054cf71c91a88"
+  integrity sha512-3d40ecwBnTP+Y7YP1lM6mkPT2oDAU5TDmLo/MIdSGEV3fW6BKbDKopBzDtW4gW6m/eoAz7psdvWfFJZbGELS/A==
+  dependencies:
+    text-encoding-utf-8 "^1.0.2"
+
 "@eslint/eslintrc@^0.4.3":
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.4.3.tgz#9e42981ef035beb3dd49add17acb96e8ff6f394c"
@@ -364,6 +371,13 @@
   integrity sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==
   dependencies:
     "@types/node" "*"
+
+"@types/bs58@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@types/bs58/-/bs58-4.0.1.tgz#3d51222aab067786d3bc3740a84a7f5a0effaa37"
+  integrity sha512-yfAgiWgVLjFCmRv8zAcOIHywYATEwiTVccTLnRp6UxTNavT55M9d/uhK3T03St/+8/z/wW+CRjGKUNmEqoHHCA==
+  dependencies:
+    base-x "^3.0.6"
 
 "@types/connect@^3.4.33":
   version "3.4.35"
@@ -695,7 +709,7 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
-base-x@^3.0.2:
+base-x@^3.0.2, base-x@^3.0.6:
   version "3.0.9"
   resolved "https://registry.yarnpkg.com/base-x/-/base-x-3.0.9.tgz#6349aaabb58526332de9f60995e548a53fe21320"
   integrity sha512-H7JU6iBHTal1gp56aKoaa//YUxEaAOUiydvrV/pILqIHXTtqxSkATOnDA2u+jZ/61sD+L/412+7kzXRtWukhpQ==
@@ -721,6 +735,11 @@ bn.js@^5.0.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.2.0.tgz#358860674396c6997771a9d051fcc1b57d4ae002"
   integrity sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==
+
+bn.js@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.2.1.tgz#0bc527a6a0d18d0aa8d5b0538ce4a77dccfa7b70"
+  integrity sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==
 
 borsh@^0.4.0:
   version "0.4.0"


### PR DESCRIPTION
This PR implements borsh encoding for both encoding function arguments and decoding their returns.

Tests will only pass after the respective changes in Solang are merged (check out [this PR](https://github.com/hyperledger/solang/pull/1053) for more information).