### PR TITLE
Fix borsh library version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,4 +15,6 @@ jobs:
     - run: yarn install
     - run: yarn lint
     - run: yarn run build:test
-    - run: yarn test
+    - run: |
+        yarn build
+        yarn test

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
         "validator": "docker run --rm -it -p 8899:8899 -p 8900:8900 solanalabs/solana:edge > /dev/null"
     },
     "dependencies": {
-        "@dao-xyz/borsh": "^3.3.0",
+        "@dao-xyz/borsh": "3.3.0",
         "@ethersproject/abi": "^5.5.0",
         "@ethersproject/bytes": "^5.5.0",
         "@ethersproject/keccak256": "^5.5.0",

--- a/test/unit/logs.test.ts
+++ b/test/unit/logs.test.ts
@@ -1,6 +1,6 @@
 import { Interface, ParamType } from '@ethersproject/abi';
 import expect from 'expect';
-import { parseLogTopic, parseTransactionError, parseTransactionLogs } from '../../src/logs';
+import { parseLogTopic, parseTransactionError, parseTransactionLogs } from '../../src';
 import { borshEncode } from '../../lib/borsh';
 
 describe('logs', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -49,7 +49,7 @@
   dependencies:
     "@cspotcode/source-map-consumer" "0.8.0"
 
-"@dao-xyz/borsh@^3.3.0":
+"@dao-xyz/borsh@3.3.0":
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/@dao-xyz/borsh/-/borsh-3.3.0.tgz#1fea8c7b405765eeb073b83ba67054cf71c91a88"
   integrity sha512-3d40ecwBnTP+Y7YP1lM6mkPT2oDAU5TDmLo/MIdSGEV3fW6BKbDKopBzDtW4gW6m/eoAz7psdvWfFJZbGELS/A==


### PR DESCRIPTION
There was a new release of `dao-xyz/borsh-ts` with breaking changes. As we are about to abandon this library, I am only removing the caret from `package.json` to avoid downloading the newest version.